### PR TITLE
Add async Slums DB query helper with circuit breaker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "PyPDF2>=3.0.1",
     "PyMySQL>=1.1.0",
     "cryptography>=41.0.0",
+    "aiomysql>=0.2.0",
 ]

--- a/slum_queries.py
+++ b/slum_queries.py
@@ -1,0 +1,148 @@
+"""Async queries for WowSlums MySQL with circuit breaker.
+
+This module exposes a small helper to run read-only queries against the
+``WowSlums`` database.  Connections are managed via an ``aiomysql`` pool whose
+min/max sizes are configured through environment variables
+``SLUM_DB_MIN_POOL`` and ``SLUM_DB_MAX_POOL``.  Queries are wrapped with
+``asyncio.wait_for`` to enforce a short timeout and a basic circuit breaker is
+used to avoid hammering the database when it is slow or down.
+
+The goal of the circuit breaker is to fail fast after repeated problems and to
+recover automatically after a cooldown period.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Iterable
+
+log = logging.getLogger("acbot.slumdb")
+
+# Pool and breaker state
+_pool: Any | None = None
+_fail_count = 0
+_breaker_until = 0.0
+
+# Configuration constants
+QUERY_TIMEOUT = float(os.getenv("SLUM_QUERY_TIMEOUT", "3"))
+FAIL_THRESHOLD = int(os.getenv("SLUM_QUERY_FAILS", "3"))
+COOLDOWN_SECONDS = float(os.getenv("SLUM_QUERY_COOLDOWN", "30"))
+
+
+class SlumQueryError(RuntimeError):
+    """Raised when the Slums database cannot be queried."""
+
+
+async def init_pool() -> Any:
+    """Initialise and return a global ``aiomysql`` connection pool.
+
+    The pool is created on first use.  ``SLUM_DB_MIN_POOL`` and
+    ``SLUM_DB_MAX_POOL`` environment variables control the min and max pool
+    sizes.  Pool creation and basic status are logged for observability.
+    """
+
+    global _pool
+    if _pool is not None:
+        return _pool
+
+    # Import lazily so test environments do not require the dependency unless
+    # the pool is actually created.
+    import aiomysql
+
+    minsize = int(os.getenv("SLUM_DB_MIN_POOL", "1"))
+    maxsize = int(os.getenv("SLUM_DB_MAX_POOL", "5"))
+
+    _pool = await aiomysql.create_pool(
+        host=os.getenv("SLUM_DB_HOST", "127.0.0.1"),
+        port=int(os.getenv("SLUM_DB_PORT", "3306")),
+        user=os.getenv("SLUM_DB_USER", ""),
+        password=os.getenv("SLUM_DB_PASS", ""),
+        db=os.getenv("SLUM_DB_NAME", ""),
+        minsize=minsize,
+        maxsize=maxsize,
+        autocommit=True,
+    )
+
+    # Log basic pool status for monitoring
+    try:
+        log.info(
+            "slum pool ready min=%s max=%s size=%s free=%s",
+            minsize,
+            maxsize,
+            _pool.size,
+            _pool.freesize,
+        )
+    except Exception:
+        log.info("slum pool ready min=%s max=%s", minsize, maxsize)
+
+    return _pool
+
+
+def _breaker_open() -> bool:
+    """Check and update breaker state."""
+
+    global _breaker_until, _fail_count
+    now = time.monotonic()
+    if _breaker_until and now < _breaker_until:
+        return True
+    if _breaker_until and now >= _breaker_until:
+        log.info("slum breaker reset")
+        _breaker_until = 0.0
+        _fail_count = 0
+    return False
+
+
+def _register_failure(exc: Exception) -> None:
+    """Record a query failure and maybe trip the breaker."""
+
+    global _fail_count, _breaker_until
+    _fail_count += 1
+    log.warning("slum query failure count=%s err=%s", _fail_count, exc)
+    if _fail_count >= FAIL_THRESHOLD or isinstance(exc, asyncio.TimeoutError):
+        _breaker_until = time.monotonic() + COOLDOWN_SECONDS
+        log.error("slum breaker opened for %.0fs", COOLDOWN_SECONDS)
+
+
+async def _run_query(sql: str, args: Iterable[Any] | None) -> list[dict[str, Any]]:
+    """Execute the SQL using the global pool and return all rows."""
+
+    pool = await init_pool()
+    try:
+        log.debug("pool status size=%s free=%s", pool.size, pool.freesize)
+    except Exception:
+        pass
+
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(sql, args or ())
+            return await cur.fetchall()
+
+
+async def query(sql: str, args: Iterable[Any] | None = None) -> Any:
+    """Run a query with timeout and circuit breaker protection."""
+
+    global _fail_count
+
+    if _breaker_open():
+        raise SlumQueryError(
+            "Slums database temporarily unavailable, please try again later."
+        )
+
+    try:
+        rows = await asyncio.wait_for(_run_query(sql, args), timeout=QUERY_TIMEOUT)
+    except Exception as exc:  # includes TimeoutError
+        _register_failure(exc)
+        raise SlumQueryError(
+            "Slums database temporarily unavailable, please try again later."
+        ) from exc
+
+    # Success resets failure counter
+    _fail_count = 0
+    return rows
+
+
+__all__ = ["init_pool", "query", "SlumQueryError"]
+

--- a/tests/test_slum_queries.py
+++ b/tests/test_slum_queries.py
@@ -1,0 +1,67 @@
+import asyncio
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import slum_queries as sq
+
+
+def test_init_pool_uses_env(monkeypatch):
+    calls = {}
+
+    class FakePool:
+        def __init__(self, **kw):
+            self.minsize = kw["minsize"]
+            self.maxsize = kw["maxsize"]
+            self.size = self.minsize
+            self.freesize = self.minsize
+
+    async def fake_create_pool(**kw):
+        calls.update(kw)
+        return FakePool(**kw)
+
+    monkeypatch.setenv("SLUM_DB_MIN_POOL", "2")
+    monkeypatch.setenv("SLUM_DB_MAX_POOL", "7")
+    monkeypatch.setitem(sys.modules, "aiomysql", SimpleNamespace(create_pool=fake_create_pool))
+
+    sq._pool = None
+    pool = asyncio.run(sq.init_pool())
+    assert pool.minsize == 2 and pool.maxsize == 7
+    assert calls["minsize"] == 2 and calls["maxsize"] == 7
+
+
+def test_circuit_breaker_timeout(monkeypatch):
+    async def slow_query(sql, args):
+        await asyncio.sleep(0.05)
+
+    monkeypatch.setattr(sq, "_run_query", slow_query)
+    monkeypatch.setattr(sq, "QUERY_TIMEOUT", 0.01, raising=False)
+    monkeypatch.setattr(sq, "FAIL_THRESHOLD", 1, raising=False)
+    monkeypatch.setattr(sq, "COOLDOWN_SECONDS", 0.05, raising=False)
+
+    sq._fail_count = 0
+    sq._breaker_until = 0.0
+
+    with pytest.raises(sq.SlumQueryError):
+        asyncio.run(sq.query("SELECT 1"))
+
+    assert sq._breaker_open()
+
+    # Second call should fail fast due to open breaker
+    start = time.monotonic()
+    with pytest.raises(sq.SlumQueryError):
+        asyncio.run(sq.query("SELECT 1"))
+    assert time.monotonic() - start < 0.02
+
+    # After cooldown breaker should reset and query succeeds
+    asyncio.run(asyncio.sleep(0.06))
+
+    async def ok_query(sql, args):
+        return [1]
+
+    monkeypatch.setattr(sq, "_run_query", ok_query)
+    res = asyncio.run(sq.query("SELECT 1"))
+    assert res == [1]
+


### PR DESCRIPTION
## Summary
- add aiomysql dependency and new `slum_queries` module
- manage aiomysql pool via env-configured min/max sizes
- wrap queries with timeout and circuit breaker and log pool/breaker state
- add tests for pool sizing and breaker behaviour

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bfa00b27ac832e8567ad58b3edd0f2