### PR TITLE
feat: add format export to metrics commands

### DIFF
--- a/commands/kpi.py
+++ b/commands/kpi.py
@@ -1,6 +1,7 @@
-import os, re, time, json, logging
+import os, re, time, json, logging, io, csv
 import discord
 from discord import app_commands
+from typing import Literal
 import ac_metrics as kpi
 from soap import SoapClient
 
@@ -24,6 +25,39 @@ def _log_cmd(name: str, t0: float, rows: int | None = None, **extra):
         pass
 
 
+async def _send_serialized(
+    itx: discord.Interaction,
+    data: object,
+    fmt: Literal["json", "csv"],
+    name: str,
+) -> None:
+    if fmt == "json":
+        buf = io.BytesIO(
+            json.dumps(data, ensure_ascii=False, default=str).encode("utf-8")
+        )
+        file = discord.File(buf, filename=f"{name}.json")
+    else:
+        out = io.StringIO()
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            w = csv.DictWriter(out, fieldnames=data[0].keys())
+            w.writeheader()
+            w.writerows(data)
+        elif isinstance(data, dict):
+            w = csv.writer(out)
+            for k, v in data.items():
+                w.writerow([k, json.dumps(v, ensure_ascii=False)])
+        else:
+            w = csv.writer(out)
+            if isinstance(data, list):
+                for row in data:
+                    w.writerow([row])
+            else:
+                w.writerow([data])
+        buf = io.BytesIO(out.getvalue().encode("utf-8"))
+        file = discord.File(buf, filename=f"{name}.csv")
+    await itx.followup.send(file=file, ephemeral=True)
+
+
 def setup_kpi(tree: app_commands.CommandTree):
     # SOAP fallback client if DB is disabled
     soap = SoapClient(
@@ -34,15 +68,25 @@ def setup_kpi(tree: app_commands.CommandTree):
     )
 
     @app_commands.command(name="wowkpi", description="Realm KPIs (online, totals, arena, top gold)")
-    async def wowkpi_cmd(itx: discord.Interaction):
+    @app_commands.describe(format="Optional export format")
+    async def wowkpi_cmd(
+        itx: discord.Interaction, format: Literal["json", "csv"] | None = None
+    ):
         t0 = time.time()
         await _send_defer(itx)
-        text = kpi.kpi_summary_text()
-        await itx.followup.send(text, ephemeral=True)
-        _log_cmd("wowkpi", t0)
+        if format:
+            data = json.loads(kpi.kpi_summary_json())
+            await _send_serialized(itx, data, format, "wowkpi")
+        else:
+            text = kpi.kpi_summary_text()
+            await itx.followup.send(text, ephemeral=True)
+        _log_cmd("wowkpi", t0, fmt=format)
 
     @app_commands.command(name="wowonline", description="Players online now")
-    async def wowonline_db(itx: discord.Interaction):
+    @app_commands.describe(format="Optional export format")
+    async def wowonline_db(
+        itx: discord.Interaction, format: Literal["json", "csv"] | None = None
+    ):
         t0 = time.time()
         await _send_defer(itx)
         n = None
@@ -63,78 +107,140 @@ def setup_kpi(tree: app_commands.CommandTree):
         if n is None:
             await itx.followup.send("⚠️ Could not determine online players.", ephemeral=True)
             return
-        await itx.followup.send(f"🟢 Players online: **{n}**", ephemeral=True)
-        _log_cmd("wowonline", t0, rows=1)
+        if format:
+            await _send_serialized(itx, {"online": n}, format, "wowonline")
+        else:
+            await itx.followup.send(f"🟢 Players online: **{n}**", ephemeral=True)
+        _log_cmd("wowonline", t0, rows=1, fmt=format)
 
     @app_commands.command(name="wowgold_top", description="Top characters by gold")
-    @app_commands.describe(limit="How many to show (default 10)")
-    async def wowgold_top(itx: discord.Interaction, limit: int = 10):
+    @app_commands.describe(
+        limit="How many to show (default 10)", format="Optional export format"
+    )
+    async def wowgold_top(
+        itx: discord.Interaction,
+        limit: int = 10,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_top_gold(limit=limit)
         if not rows:
             return await itx.followup.send("No data.", ephemeral=True)
-        lines = [
-            f"{i+1}. **{r['name']}** (Lv {r['level']}) — {kpi.copper_to_gold_s(r['money'])}"
-            for i, r in enumerate(rows)
-        ]
-        await itx.followup.send("\n".join(lines), ephemeral=True)
-        _log_cmd("wowgold_top", t0, rows=len(rows), limit=limit)
+        if format:
+            await _send_serialized(itx, rows, format, "wowgold_top")
+        else:
+            lines = [
+                f"{i+1}. **{r['name']}** (Lv {r['level']}) — {kpi.copper_to_gold_s(r['money'])}"
+                for i, r in enumerate(rows)
+            ]
+            await itx.followup.send("\n".join(lines), ephemeral=True)
+        _log_cmd("wowgold_top", t0, rows=len(rows), limit=limit, fmt=format)
 
     @app_commands.command(name="wowlevels", description="Level distribution")
-    async def wowlevels(itx: discord.Interaction):
+    @app_commands.describe(format="Optional export format")
+    async def wowlevels(
+        itx: discord.Interaction, format: Literal["json", "csv"] | None = None
+    ):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_level_distribution()
-        out = " | ".join([f"{r['level']}:{r['n']}" for r in rows]) if rows else "No data."
-        await itx.followup.send(f"📊 Levels → {out}", ephemeral=True)
-        _log_cmd("wowlevels", t0, rows=len(rows))
+        if format:
+            await _send_serialized(itx, rows, format, "wowlevels")
+        else:
+            out = " | ".join([f"{r['level']}:{r['n']}" for r in rows]) if rows else "No data."
+            await itx.followup.send(f"📊 Levels → {out}", ephemeral=True)
+        _log_cmd("wowlevels", t0, rows=len(rows), fmt=format)
 
     @app_commands.command(name="wowguilds", description="Most active guilds (last N days)")
-    @app_commands.describe(days="Days window (default 14)", limit="Max rows (default 10)")
-    async def wowguilds(itx: discord.Interaction, days: int = 14, limit: int = 10):
+    @app_commands.describe(
+        days="Days window (default 14)",
+        limit="Max rows (default 10)",
+        format="Optional export format",
+    )
+    async def wowguilds(
+        itx: discord.Interaction,
+        days: int = 14,
+        limit: int = 10,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_guild_activity(days=days, limit=limit)
         if not rows:
             return await itx.followup.send("No data.", ephemeral=True)
-        out = "\n".join([f"{r['guild']}: {r['active_members']}" for r in rows])
-        await itx.followup.send(out, ephemeral=True)
-        _log_cmd("wowguilds", t0, rows=len(rows), days=days, limit=limit)
+        if format:
+            await _send_serialized(itx, rows, format, "wowguilds")
+        else:
+            out = "\n".join([f"{r['guild']}: {r['active_members']}" for r in rows])
+            await itx.followup.send(out, ephemeral=True)
+        _log_cmd("wowguilds", t0, rows=len(rows), days=days, limit=limit, fmt=format)
 
     @app_commands.command(name="wowah_hot", description="Most listed items on AH")
-    @app_commands.describe(limit="Max rows (default 10)")
-    async def wowah_hot(itx: discord.Interaction, limit: int = 10):
+    @app_commands.describe(limit="Max rows (default 10)", format="Optional export format")
+    async def wowah_hot(
+        itx: discord.Interaction,
+        limit: int = 10,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_auction_hot_items(limit=limit)
         if not rows:
             return await itx.followup.send("No data.", ephemeral=True)
-        out_lines = []
-        for r in rows:
-            name = r.get("name") or f"Template {r['item_template']}"
-            out_lines.append(f"{name}: {int(r['listings'])} listings, avg {kpi.copper_to_gold_s(r['avg_buyout'])}")
-        await itx.followup.send("\n".join(out_lines), ephemeral=True)
-        _log_cmd("wowah_hot", t0, rows=len(rows), limit=limit)
+        if format:
+            await _send_serialized(itx, rows, format, "wowah_hot")
+        else:
+            out_lines = []
+            for r in rows:
+                name = r.get("name") or f"Template {r['item_template']}"
+                out_lines.append(
+                    f"{name}: {int(r['listings'])} listings, avg {kpi.copper_to_gold_s(r['avg_buyout'])}"
+                )
+            await itx.followup.send("\n".join(out_lines), ephemeral=True)
+        _log_cmd("wowah_hot", t0, rows=len(rows), limit=limit, fmt=format)
 
     @app_commands.command(name="wowarena", description="Arena rating distribution (top buckets)")
-    @app_commands.describe(top="How many rows (default 20)")
-    async def wowarena(itx: discord.Interaction, top: int = 20):
+    @app_commands.describe(top="How many rows (default 20)", format="Optional export format")
+    async def wowarena(
+        itx: discord.Interaction,
+        top: int = 20,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_arena_rating_distribution(limit_rows=top)
-        out = " | ".join([f"{r['rating']}:{r['teams']}" for r in rows]) if rows else "No data."
-        await itx.followup.send(out, ephemeral=True)
-        _log_cmd("wowarena", t0, rows=len(rows), top=top)
+        if format:
+            await _send_serialized(itx, rows, format, "wowarena")
+        else:
+            out = " | ".join([f"{r['rating']}:{r['teams']}" for r in rows]) if rows else "No data."
+            await itx.followup.send(out, ephemeral=True)
+        _log_cmd("wowarena", t0, rows=len(rows), top=top, fmt=format)
 
     @app_commands.command(name="wowprof", description="Profession counts ≥ threshold (skill_id, min_value)")
-    @app_commands.describe(skill_id="Profession skill id (e.g., Enchanting=333)", min_value="Min value (default 300)")
-    async def wowprof(itx: discord.Interaction, skill_id: int, min_value: int = 300):
+    @app_commands.describe(
+        skill_id="Profession skill id (e.g., Enchanting=333)",
+        min_value="Min value (default 300)",
+        format="Optional export format",
+    )
+    async def wowprof(
+        itx: discord.Interaction,
+        skill_id: int,
+        min_value: int = 300,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         n = kpi.kpi_profession_counts(skill_id=skill_id, min_value=min_value)
-        await itx.followup.send(f"🛠️ Skill {skill_id} ≥ {min_value}: **{n}** characters", ephemeral=True)
-        _log_cmd("wowprof", t0, rows=1, skill_id=skill_id, min_value=min_value)
+        if format:
+            data = {"skill_id": skill_id, "min_value": min_value, "count": n}
+            await _send_serialized(itx, data, format, "wowprof")
+        else:
+            await itx.followup.send(
+                f"🛠️ Skill {skill_id} ≥ {min_value}: **{n}** characters",
+                ephemeral=True,
+            )
+        _log_cmd("wowprof", t0, rows=1, skill_id=skill_id, min_value=min_value, fmt=format)
 
     # Register all
     tree.add_command(wowkpi_cmd)
@@ -146,8 +252,17 @@ def setup_kpi(tree: app_commands.CommandTree):
     tree.add_command(wowprof)
 
     @app_commands.command(name="wowfind_char", description="Find characters by name (partial match)")
-    @app_commands.describe(name="Name or part of name", limit="Max rows (default 10)")
-    async def wowfind_char(itx: discord.Interaction, name: str, limit: int = 10):
+    @app_commands.describe(
+        name="Name or part of name",
+        limit="Max rows (default 10)",
+        format="Optional export format",
+    )
+    async def wowfind_char(
+        itx: discord.Interaction,
+        name: str,
+        limit: int = 10,
+        format: Literal["json", "csv"] | None = None,
+    ):
         t0 = time.time()
         await _send_defer(itx)
         try:
@@ -157,12 +272,15 @@ def setup_kpi(tree: app_commands.CommandTree):
         if not rows:
             await itx.followup.send("No characters found.", ephemeral=True)
             return
-        lines = []
-        for r in rows:
-            online = "🟢" if r.get("online") else "⚫"
-            guild = r.get("guild") or "(no guild)"
-            lines.append(f"{online} {r['name']} (Lv {r['level']}) — {guild}")
-        await itx.followup.send("\n".join(lines), ephemeral=True)
-        _log_cmd("wowfind_char", t0, rows=len(rows), query=name, limit=limit)
+        if format:
+            await _send_serialized(itx, rows, format, "wowfind_char")
+        else:
+            lines = []
+            for r in rows:
+                online = "🟢" if r.get("online") else "⚫"
+                guild = r.get("guild") or "(no guild)"
+                lines.append(f"{online} {r['name']} (Lv {r['level']}) — {guild}")
+            await itx.followup.send("\n".join(lines), ephemeral=True)
+        _log_cmd("wowfind_char", t0, rows=len(rows), query=name, limit=limit, fmt=format)
 
     tree.add_command(wowfind_char)


### PR DESCRIPTION
## Summary
- add helper to serialize metric results to JSON or CSV files
- expose optional `format` parameter on metric slash commands

## Testing
- `python -m py_compile commands/kpi.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pymysql')*


------
https://chatgpt.com/codex/tasks/task_b_68bfa00bb61c832e827de035eaa60d70