### PR TITLE
docs: document server insights and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Setup
    RAG_DOCS_TOPK=2
    RAG_MIN_SCORE=10
    RAG_MAX_CHARS=3000
+   RAG_IN_AUTOREPLY=true
    # Optional: enable Ollama chat
    OLLAMA_ENABLED=true
    OLLAMA_HOST=http://127.0.0.1:11434
@@ -79,6 +80,10 @@ Setup
    SUPPORT_URL=https://discord.gg/yourserver
    # Optional: vision support (use a vision-capable model like llava)
    OLLAMA_VISION_ENABLED=true
+   # Optional: enable tool-based server insights
+   OLLAMA_TOOLS_ENABLED=true
+   # Optional: per-user QPS limit for tool queries
+   INSIGHTS_QPS=5
 
 Ollama
 
@@ -136,6 +141,7 @@ Slash Commands
  - /wowah_hot [limit]: Auction hot items
  - /wowarena [top]: Arena rating distribution
  - /wowprof [skill_id] [min_value]: Profession counts
+ - /wowfind_char [name] [limit]: Search for characters by name
  - /health: Bot health ping
  - /wowimage: Generate an image (if provider supports).
  - /wowupscale: Upscale an image (if provider supports).
@@ -172,6 +178,14 @@ Curated documents
 - Search: `/wowdocs query:"..."` shows top passages with ids; `/wowdocs_show id:<id>` shows the full passage.
 - Reload docs without restart: `/wowdocs_reload` (Manage Server required).
 - RAG: Top `RAG_DOCS_TOPK` passages are automatically included as additional context when generating answers.
+
+Server Insights
+---------------
+
+- Enable named queries such as realm KPIs or guild activity with `OLLAMA_TOOLS_ENABLED=true`.
+- Results are cached for `METRICS_TTL_SECONDS` (default 8s) to avoid hammering the DB.
+- A simple per-user rate limiter enforces `INSIGHTS_QPS` queries per second.
+- RAG settings (`RAG_*`, e.g. `RAG_IN_AUTOREPLY`) control how KB snippets are injected.
 
 DB-backed metrics
 -----------------

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,6 +12,9 @@ DB_PASS=CHANGE_ME
 DB_AUTH_DB=auth
 DB_CHAR_DB=characters
 DB_WORLD_DB=world
+METRICS_TTL_SECONDS=8
+INSIGHTS_QPS=5
+OLLAMA_TOOLS_ENABLED=true
 
 Commands
 --------
@@ -24,6 +27,34 @@ Commands
 - /wowah_hot [limit=10] — auction hot items (by item_template)
 - /wowarena [top=20] — rating:teams pairs
 - /wowprof [skill_id] [min_value=300] — profession counts
+- /wowfind_char [name] [limit=10] — search characters by name
+- /health — bot health ping
+
+Usage examples
+--------------
+
+```text
+/wowkpi
+🟢 Online now: **41**
+🧍 Characters: **120**, 👤 Accounts: **40**
+🏟️ Arena (top buckets): 2200:5 | 2100:8
+💰 Top gold: Alice (Lv 80): 123g 45s 67c
+```
+
+```text
+/health
+✅ ACbot ok (uptime 2h, DB 12ms)
+```
+
+Exports
+-------
+
+Most commands accept `format:json` or `format:csv` to download data.
+
+```text
+/wowkpi format:json
+{"online":41,"totals":{"total_chars":120,"total_accounts":40}}
+```
 
 Schema notes (AzerothCore defaults)
 -----------------------------------
@@ -40,9 +71,22 @@ Schema notes (AzerothCore defaults)
 Common profession skill IDs
 ---------------------------
 
-- Alchemy=171, Herbalism=182, Mining=186, Blacksmithing=164, Leatherworking=165
-- Engineering=202, Enchanting=333, Tailoring=197, Skinning=393, Cooking=185
-- First Aid=129, Fishing=356, Jewelcrafting=755, Inscription=773
+| Profession       | ID  |
+|------------------|-----|
+| Alchemy          | 171 |
+| Herbalism        | 182 |
+| Mining           | 186 |
+| Blacksmithing    | 164 |
+| Leatherworking   | 165 |
+| Engineering      | 202 |
+| Enchanting       | 333 |
+| Tailoring        | 197 |
+| Skinning         | 393 |
+| Cooking          | 185 |
+| First Aid        | 129 |
+| Fishing          | 356 |
+| Jewelcrafting    | 755 |
+| Inscription      | 773 |
 
 Money units
 -----------


### PR DESCRIPTION
## Summary
- add Server Insights docs with named queries, caching, and rate limits
- expand metrics guide with usage examples, profession IDs, and export tips

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ac_metrics')*


------
https://chatgpt.com/codex/tasks/task_b_68bfa013558c832e9f529b63e608be2a