### PR TITLE
feat: normalize metrics output via formatter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ from discord.ui import Modal, TextInput
 from dotenv import load_dotenv
 import requests
 from utils import json_load, json_save_atomic, chunk_text, send_ephemeral, send_long_ephemeral, send_long_reply
+from utils.formatter import normalize_ratio, wrap_response
 from utils.intent import classify as classify_intent
 from soap import SoapClient
 from ollama import OllamaClient
@@ -378,7 +379,7 @@ def get_rates_lines() -> list[str]:
         if not val:
             val = globals().get(k_env, "")
         if val:
-            lines.append(f"- {label}: {val}")
+            lines.append(f"- {label}: {normalize_ratio(val)}")
     add("XP_RATE", "XP")
     add("QUEST_XP_RATE", "Quest XP")
     add("DROP_RATE", "Drop")
@@ -923,19 +924,38 @@ class Bot(discord.Client):
                         try:
                             if name == "online_count":
                                 n = kpi.kpi_players_online()
-                                return await message.reply(f"🟢 Players online: {n}", mention_author=False)
+                                return await message.reply(
+                                    wrap_response("Players online", str(n)), mention_author=False
+                                )
                             if name == "total_characters":
                                 totals = kpi.kpi_totals()
-                                return await message.reply(f"Characters: {totals.get('total_chars', 0)}", mention_author=False)
+                                return await message.reply(
+                                    wrap_response(
+                                        "Characters", str(totals.get("total_chars", 0))
+                                    ),
+                                    mention_author=False,
+                                )
                             if name == "total_accounts":
                                 totals = kpi.kpi_totals()
-                                return await message.reply(f"Accounts: {totals.get('total_accounts', 0)}", mention_author=False)
+                                return await message.reply(
+                                    wrap_response(
+                                        "Accounts", str(totals.get("total_accounts", 0))
+                                    ),
+                                    mention_author=False,
+                                )
                             if name == "auction_count":
                                 n = kpi.kpi_auction_count()
-                                return await message.reply(f"Active auctions: {n}", mention_author=False)
+                                return await message.reply(
+                                    wrap_response("Active auctions", str(n)),
+                                    mention_author=False,
+                                )
                             if name == "server_rates":
                                 lines = get_rates_lines()
-                                return await message.reply("Server rates:\n" + ("\n".join(lines) if lines else "No rates configured."), mention_author=False)
+                                rates = "\n".join(lines) if lines else "No rates configured."
+                                return await message.reply(
+                                    wrap_response("Server rates", "\n" + rates),
+                                    mention_author=False,
+                                )
                             if name == "gold_per_hour":
                                 return await message.reply("I don’t track gold per hour. Try /wowgold_top or /wowah_hot.", mention_author=False)
                             if name == "bots_count":
@@ -1083,7 +1103,9 @@ async def wowrates(interaction: discord.Interaction):
     lines = get_rates_lines()
     if not lines:
         return await interaction.response.send_message("No rates configured.", ephemeral=True)
-    await interaction.response.send_message("Server rates:\n" + "\n".join(lines), ephemeral=True)
+    await interaction.response.send_message(
+        wrap_response("Server rates", "\n" + "\n".join(lines)), ephemeral=True
+    )
 
 @bot.tree.command(name="wowbots", description="Show bot status via SOAP (if configured)")
 async def wowbots(interaction: discord.Interaction):
@@ -1310,19 +1332,32 @@ async def wowask(interaction: discord.Interaction, prompt: str):
                 name, slots = intent
                 if name == "online_count":
                     n = kpi.kpi_players_online()
-                    return await interaction.followup.send(f"🟢 Players online: {n}", ephemeral=True)
+                    return await interaction.followup.send(
+                        wrap_response("Players online", str(n)), ephemeral=True
+                    )
                 if name == "total_characters":
                     totals = kpi.kpi_totals()
-                    return await interaction.followup.send(f"Characters: {totals.get('total_chars', 0)}", ephemeral=True)
+                    return await interaction.followup.send(
+                        wrap_response("Characters", str(totals.get("total_chars", 0))),
+                        ephemeral=True,
+                    )
                 if name == "total_accounts":
                     totals = kpi.kpi_totals()
-                    return await interaction.followup.send(f"Accounts: {totals.get('total_accounts', 0)}", ephemeral=True)
+                    return await interaction.followup.send(
+                        wrap_response("Accounts", str(totals.get("total_accounts", 0))),
+                        ephemeral=True,
+                    )
                 if name == "auction_count":
                     n = kpi.kpi_auction_count()
-                    return await interaction.followup.send(f"Active auctions: {n}", ephemeral=True)
+                    return await interaction.followup.send(
+                        wrap_response("Active auctions", str(n)), ephemeral=True
+                    )
                 if name == "server_rates":
                     lines = get_rates_lines()
-                    return await interaction.followup.send("Server rates:\n" + ("\n".join(lines) if lines else "No rates configured."), ephemeral=True)
+                    rates = "\n".join(lines) if lines else "No rates configured."
+                    return await interaction.followup.send(
+                        wrap_response("Server rates", "\n" + rates), ephemeral=True
+                    )
                 if name == "gold_per_hour":
                     return await interaction.followup.send("I don’t track gold per hour. Try /wowgold_top or /wowah_hot.", ephemeral=True)
                 if name == "bots_count":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ dependencies = [
     "PyMySQL>=1.1.0",
     "cryptography>=41.0.0",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = "."

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,18 @@
+from utils.formatter import normalize_ratio, format_gold, normalize_item_name, wrap_response
+
+
+def test_format_gold():
+    assert format_gold(1234567) == "123g 45s 67c"
+
+
+def test_normalize_ratio():
+    assert normalize_ratio(2) == "2x"
+    assert normalize_ratio("1.234x") == "1.23x"
+
+
+def test_normalize_item_name():
+    assert normalize_item_name("cracked_egg") == "Cracked Egg"
+
+
+def test_wrap_response():
+    assert wrap_response("Players", "10") == "Players: 10 — source: Slum DB"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import json
 import os
 from typing import List
 
-import discord
+try:
+    import discord  # type: ignore
+except Exception:  # pragma: no cover - allow import without discord
+    discord = None  # type: ignore
 
 
 def json_load(path: str, default):

--- a/utils/formatter.py
+++ b/utils/formatter.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Formatting helpers for metrics and bot responses.
+
+This module centralizes small formatting utilities so both slash commands
+and LLM tool responses produce consistent output before sending to Discord
+or models.
+"""
+
+from typing import Any
+
+
+def normalize_ratio(value: Any) -> str:
+    """Return a canonical representation of a ratio like ``1x``.
+
+    Accepts numbers or strings optionally suffixed with ``x``. The output
+    is trimmed to at most two decimal places and always suffixed with ``x``.
+    Unparsable values are returned as-is.
+    """
+    if value is None:
+        return ""
+    s = str(value).strip().lower()
+    if s.endswith("x"):
+        s = s[:-1]
+    try:
+        f = float(s)
+    except ValueError:
+        return str(value)
+    if f.is_integer():
+        return f"{int(f)}x"
+    # format with up to 2 decimals, strip trailing zeros/point
+    return f"{f:.2f}".rstrip("0").rstrip(".") + "x"
+
+
+def format_gold(copper: int) -> str:
+    """Convert copper units to ``g s c`` string."""
+    g, rem = divmod(int(copper or 0), 10_000)
+    s, c = divmod(rem, 100)
+    parts: list[str] = []
+    if g:
+        parts.append(f"{g}g")
+    if s:
+        parts.append(f"{s}s")
+    if c or not parts:
+        parts.append(f"{c}c")
+    return " ".join(parts)
+
+
+def normalize_item_name(name: Any) -> str:
+    """Standardize item names (title case, spaces instead of underscores)."""
+    s = str(name or "").replace("_", " ").strip()
+    return " ".join(w.capitalize() for w in s.split())
+
+
+def wrap_response(metric: str, value: str) -> str:
+    """Wrap a metric/value pair in the standard template."""
+    return f"{metric}: {value} — source: Slum DB"


### PR DESCRIPTION
## Summary
- add `formatter` helpers to normalize ratios, gold and item names
- wrap metrics replies in `Metric: value — source: Slum DB`
- route slash commands and LLM tool replies through new formatter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bfa0105ef8832ea0a200d3ba27c653