### PR TITLE
Add totals and delta metrics to auction hot items

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Slash Commands
  - /wowlevels: Level distribution
  - /wowgold_top [limit]: Richest characters
  - /wowguilds [days] [limit]: Active guilds
- - /wowah_hot [limit]: Auction hot items
+ - /wowah_hot [limit]: Auction hot items with totals and 24h delta
  - /wowarena [top]: Arena rating distribution
  - /wowprof [skill_id] [min_value]: Profession counts
  - /health: Bot health ping

--- a/commands/kpi.py
+++ b/commands/kpi.py
@@ -113,7 +113,13 @@ def setup_kpi(tree: app_commands.CommandTree):
         out_lines = []
         for r in rows:
             name = r.get("name") or f"Template {r['item_template']}"
-            out_lines.append(f"{name}: {int(r['listings'])} listings, avg {kpi.copper_to_gold_s(r['avg_buyout'])}")
+            delta = r.get("delta_24h")
+            delta_s = f" (Δ24h {delta:+d})" if delta is not None else ""
+            out_lines.append(
+                f"{name}: {int(r['listings'])} listings{delta_s}, {int(r['sellers'])} sellers, "
+                f"total {kpi.copper_to_gold_s(r['total_buyout'])} / {kpi.copper_to_gold_s(r['total_bid'])}, "
+                f"avg {kpi.copper_to_gold_s(r['avg_buyout'])}"
+            )
         await itx.followup.send("\n".join(out_lines), ephemeral=True)
         _log_cmd("wowah_hot", t0, rows=len(rows), limit=limit)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,7 +21,7 @@ Commands
 - /wowgold_top [limit]
 - /wowlevels — level distribution
 - /wowguilds [days=14] [limit=10]
-- /wowah_hot [limit=10] — auction hot items (by item_template)
+- /wowah_hot [limit=10] — auction hot items with totals and 24h delta
 - /wowarena [top=20] — rating:teams pairs
 - /wowprof [skill_id] [min_value=300] — profession counts
 


### PR DESCRIPTION
## Summary
- enrich `/wowah_hot` with total buyout/bid, average buyout, seller count, and 24h delta
- cache auction hot snapshot to compute daily changes
- document expanded auction metrics

## Testing
- `python -m py_compile ac_metrics.py commands/kpi.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pymysql')*
- `pip install pymysql` *(fails: Could not find a version that satisfies the requirement pymysql)*

------
https://chatgpt.com/codex/tasks/task_b_68bfa00db338832eb88f1be77f9269ec