### PR TITLE
Refactor KPI output with shared formatters and embeds

### DIFF
--- a/ac_metrics.py
+++ b/ac_metrics.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple
 
 import pymysql
-
+from utils.formatters import copper_to_gsc
 
 DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
 DB_PORT = int(os.getenv("DB_PORT", "3306"))
@@ -66,19 +66,6 @@ def _has_table(dbname: str, table: str) -> bool:
         ok = cur.fetchone()["n"] > 0
     _cache_set(key, ok, ttl=60)
     return ok
-
-
-def copper_to_gold_s(copper: int) -> str:
-    g, rem = divmod(int(copper or 0), 10000)
-    s, c = divmod(rem, 100)
-    out: List[str] = []
-    if g:
-        out.append(f"{g}g")
-    if s:
-        out.append(f"{s}s")
-    if c or not out:
-        out.append(f"{c}c")
-    return " ".join(out)
 
 
 def kpi_players_online() -> int:
@@ -274,7 +261,7 @@ def kpi_summary_text() -> str:
         lines.append(f"🏟️ Arena (top buckets): {head}")
     if topgold:
         tg = " | ".join(
-            f"{r['name']} (Lv {r['level']}): {copper_to_gold_s(r['money'])}" for r in topgold
+            f"{r['name']} (Lv {r['level']}): {copper_to_gsc(r['money'])}" for r in topgold
         )
         lines.append(f"💰 Top gold: {tg}")
     return "\n".join(lines)

--- a/commands/kpi.py
+++ b/commands/kpi.py
@@ -3,6 +3,7 @@ import discord
 from discord import app_commands
 import ac_metrics as kpi
 from soap import SoapClient
+from utils.formatters import copper_to_gsc, rows_to_embed
 
 
 async def _send_defer(itx: discord.Interaction):
@@ -75,10 +76,10 @@ def setup_kpi(tree: app_commands.CommandTree):
         if not rows:
             return await itx.followup.send("No data.", ephemeral=True)
         lines = [
-            f"{i+1}. **{r['name']}** (Lv {r['level']}) — {kpi.copper_to_gold_s(r['money'])}"
+            f"{i+1}. **{r['name']}** (Lv {r['level']}) — {copper_to_gsc(r['money'])}"
             for i, r in enumerate(rows)
         ]
-        await itx.followup.send("\n".join(lines), ephemeral=True)
+        await itx.followup.send(embed=rows_to_embed("Top characters by gold", lines), ephemeral=True)
         _log_cmd("wowgold_top", t0, rows=len(rows), limit=limit)
 
     @app_commands.command(name="wowlevels", description="Level distribution")
@@ -86,8 +87,10 @@ def setup_kpi(tree: app_commands.CommandTree):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_level_distribution()
-        out = " | ".join([f"{r['level']}:{r['n']}" for r in rows]) if rows else "No data."
-        await itx.followup.send(f"📊 Levels → {out}", ephemeral=True)
+        if not rows:
+            return await itx.followup.send("No data.", ephemeral=True)
+        lines = [f"{r['level']}: {r['n']}" for r in rows]
+        await itx.followup.send(embed=rows_to_embed("Level distribution", lines), ephemeral=True)
         _log_cmd("wowlevels", t0, rows=len(rows))
 
     @app_commands.command(name="wowguilds", description="Most active guilds (last N days)")
@@ -98,8 +101,10 @@ def setup_kpi(tree: app_commands.CommandTree):
         rows = kpi.kpi_guild_activity(days=days, limit=limit)
         if not rows:
             return await itx.followup.send("No data.", ephemeral=True)
-        out = "\n".join([f"{r['guild']}: {r['active_members']}" for r in rows])
-        await itx.followup.send(out, ephemeral=True)
+        lines = [f"{r['guild']}: {r['active_members']}" for r in rows]
+        await itx.followup.send(
+            embed=rows_to_embed("Most active guilds", lines), ephemeral=True
+        )
         _log_cmd("wowguilds", t0, rows=len(rows), days=days, limit=limit)
 
     @app_commands.command(name="wowah_hot", description="Most listed items on AH")
@@ -113,8 +118,12 @@ def setup_kpi(tree: app_commands.CommandTree):
         out_lines = []
         for r in rows:
             name = r.get("name") or f"Template {r['item_template']}"
-            out_lines.append(f"{name}: {int(r['listings'])} listings, avg {kpi.copper_to_gold_s(r['avg_buyout'])}")
-        await itx.followup.send("\n".join(out_lines), ephemeral=True)
+            out_lines.append(
+                f"{name}: {int(r['listings'])} listings, avg {copper_to_gsc(r['avg_buyout'])}"
+            )
+        await itx.followup.send(
+            embed=rows_to_embed("Most listed items on AH", out_lines), ephemeral=True
+        )
         _log_cmd("wowah_hot", t0, rows=len(rows), limit=limit)
 
     @app_commands.command(name="wowarena", description="Arena rating distribution (top buckets)")
@@ -123,8 +132,12 @@ def setup_kpi(tree: app_commands.CommandTree):
         t0 = time.time()
         await _send_defer(itx)
         rows = kpi.kpi_arena_rating_distribution(limit_rows=top)
-        out = " | ".join([f"{r['rating']}:{r['teams']}" for r in rows]) if rows else "No data."
-        await itx.followup.send(out, ephemeral=True)
+        if not rows:
+            return await itx.followup.send("No data.", ephemeral=True)
+        lines = [f"{r['rating']}: {r['teams']}" for r in rows]
+        await itx.followup.send(
+            embed=rows_to_embed("Arena rating distribution", lines), ephemeral=True
+        )
         _log_cmd("wowarena", t0, rows=len(rows), top=top)
 
     @app_commands.command(name="wowprof", description="Profession counts ≥ threshold (skill_id, min_value)")
@@ -162,7 +175,9 @@ def setup_kpi(tree: app_commands.CommandTree):
             online = "🟢" if r.get("online") else "⚫"
             guild = r.get("guild") or "(no guild)"
             lines.append(f"{online} {r['name']} (Lv {r['level']}) — {guild}")
-        await itx.followup.send("\n".join(lines), ephemeral=True)
+        await itx.followup.send(
+            embed=rows_to_embed("Characters", lines), ephemeral=True
+        )
         _log_cmd("wowfind_char", t0, rows=len(rows), query=name, limit=limit)
 
     tree.add_command(wowfind_char)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,11 +1,11 @@
-import ac_metrics as kpi
+from utils.formatters import copper_to_gsc
 
 
-def test_copper_to_gold_s_basic():
-    assert kpi.copper_to_gold_s(0) == "0c"
-    assert kpi.copper_to_gold_s(99) == "99c"
-    assert kpi.copper_to_gold_s(100) == "1s"
-    assert kpi.copper_to_gold_s(101) == "1s 1c"
-    assert kpi.copper_to_gold_s(10000) == "1g"
-    assert kpi.copper_to_gold_s(1234567) == "123g 45s 67c"
+def test_copper_to_gsc_basic():
+    assert copper_to_gsc(0) == "0c"
+    assert copper_to_gsc(99) == "99c"
+    assert copper_to_gsc(100) == "1s"
+    assert copper_to_gsc(101) == "1s 1c"
+    assert copper_to_gsc(10000) == "1g"
+    assert copper_to_gsc(1234567) == "123g 45s 67c"
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import json
 import os
 from typing import List
 
-import discord
+try:  # pragma: no cover - fallback when discord is missing
+    import discord  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    discord = None  # type: ignore
 
 
 def json_load(path: str, default):

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Iterable, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import discord  # type: ignore
+except Exception:  # pragma: no cover
+    discord = None  # type: ignore
+
+
+def copper_to_gsc(copper: int) -> str:
+    g, rem = divmod(int(copper or 0), 10000)
+    s, c = divmod(rem, 100)
+    parts: list[str] = []
+    if g:
+        parts.append(f"{g}g")
+    if s:
+        parts.append(f"{s}s")
+    if c or not parts:
+        parts.append(f"{c}c")
+    return " ".join(parts)
+
+
+def rows_to_embed(title: str, rows: Iterable[str], color: int = 0x2ECC71) -> discord.Embed:
+    embed = discord.Embed(title=title, color=color)
+    rows = list(rows)
+    if rows:
+        embed.description = "\n".join(rows)
+    return embed
+
+
+def kv_to_embed(title: str, items: Iterable[Tuple[str, str]], color: int = 0x2ECC71) -> discord.Embed:
+    embed = discord.Embed(title=title, color=color)
+    for name, value in items:
+        embed.add_field(name=name, value=value, inline=False)
+    return embed


### PR DESCRIPTION
## Summary
- add `copper_to_gsc` and embed helpers
- refactor KPI commands to use centralized formatting
- convert metrics summary to new currency helper

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bfa006bc84832e961894b1ab36c0e1