### PR TITLE
Add active guild metrics and slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simple Discord bot for AzerothCore that uses SOAP to:
   - Knowledge base: Search 3.3.5a cheatsheet via `/wowkb` and `/wowkb_show`
   - RAG (optional): Answers use local KB + server info as context
   - Curated docs: Drop `.md`/`.txt` in `docs/`, search via `/wowdocs`
-  - Metrics (DB): Realm KPIs via `/wowkpi`, `/wowlevels`, `/wowgold_top`, `/wowguilds`, `/wowah_hot`, `/wowarena`, `/wowprof`
+  - Metrics (DB): Realm KPIs via `/wowkpi`, `/wowlevels`, `/wowgold_top`, `/wowguilds`, `/wowactive_guilds`, `/wowah_hot`, `/wowarena`, `/wowprof`
   - Images (provider-dependent): `/wowimage` (txt2img), `/wowupscale` (upscale)
 
 Requirements
@@ -133,6 +133,7 @@ Slash Commands
  - /wowlevels: Level distribution
  - /wowgold_top [limit]: Richest characters
  - /wowguilds [days] [limit]: Active guilds
+ - /wowactive_guilds [days] [limit]: Active guilds with cached delta
  - /wowah_hot [limit]: Auction hot items
  - /wowarena [top]: Arena rating distribution
  - /wowprof [skill_id] [min_value]: Profession counts

--- a/ac_metrics.py
+++ b/ac_metrics.py
@@ -3,7 +3,11 @@ import time
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple
 
-import pymysql
+# PyMySQL is optional for environments without DB access (e.g., tests).
+try:
+    import pymysql
+except Exception:  # pragma: no cover - handled at runtime
+    pymysql = None
 
 
 DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
@@ -16,7 +20,7 @@ DB_WORLD = os.getenv("DB_WORLD_DB", os.getenv("DB_WORLD", "world"))
 
 TTL_HOT = int(os.getenv("METRICS_TTL_SECONDS", "8"))
 
-DICT = pymysql.cursors.DictCursor
+DICT = pymysql.cursors.DictCursor if pymysql else None
 _cache: Dict[Any, Dict[str, Any]] = {}
 
 
@@ -36,6 +40,8 @@ def _cache_set(key, val, ttl=TTL_HOT):
 
 @contextmanager
 def conn(dbname: str):
+    if not pymysql:  # pragma: no cover - protective guard
+        raise RuntimeError("pymysql is required for DB connections")
     cn = pymysql.connect(
         host=DB_HOST,
         port=DB_PORT,
@@ -155,6 +161,33 @@ def kpi_guild_activity(days: int = 14, limit: int = 10) -> List[Dict[str, Any]]:
     with conn(DB_CHAR) as c, c.cursor() as cur:
         cur.execute(q, (days, limit))
         return cur.fetchall()
+
+
+def active_guilds(window_secs: int, limit: int = 10) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]] | None]:
+    """Guild member counts for characters active within ``window_secs``.
+
+    Returns a tuple of ``(rows, previous_rows)`` where ``previous_rows`` is the
+    cached result from the last call with the same parameters, if available.
+    """
+    key = f"active_guilds:{window_secs}:{limit}"
+    prev = _cache_get(key)
+    q = (
+        """
+    SELECT g.name AS guild, COUNT(*) AS active_members
+    FROM guild_member gm
+    JOIN characters c ON c.guid = gm.guid
+    JOIN guild g ON g.guildid = gm.guildid
+    WHERE c.logout_time >= UNIX_TIMESTAMP() - %s
+    GROUP BY g.name
+    ORDER BY active_members DESC
+    LIMIT %s
+    """
+    )
+    with conn(DB_CHAR) as c, c.cursor() as cur:
+        cur.execute(q, (int(window_secs), int(limit)))
+        rows = cur.fetchall()
+    _cache_set(key, rows)
+    return rows, prev
 
 
 def kpi_auction_hot_items(limit: int = 10) -> List[Dict[str, Any]]:

--- a/commands/kpi.py
+++ b/commands/kpi.py
@@ -102,6 +102,31 @@ def setup_kpi(tree: app_commands.CommandTree):
         await itx.followup.send(out, ephemeral=True)
         _log_cmd("wowguilds", t0, rows=len(rows), days=days, limit=limit)
 
+    @app_commands.command(name="wowactive_guilds", description="Guild activity over N days (cached delta)")
+    @app_commands.describe(days="Days window (default 14)", limit="Max rows (default 10)")
+    async def wowactive_guilds(itx: discord.Interaction, days: int = 14, limit: int = 10):
+        t0 = time.time()
+        await _send_defer(itx)
+        window_secs = max(1, days) * 86400
+        rows, prev = kpi.active_guilds(window_secs=window_secs, limit=limit)
+        if not rows:
+            return await itx.followup.send("No data.", ephemeral=True)
+        prev_map = {r["guild"]: r["active_members"] for r in prev} if prev else {}
+        lines = []
+        for r in rows:
+            guild = r["guild"]
+            count = r["active_members"]
+            delta = None
+            if guild in prev_map:
+                delta = count - prev_map[guild]
+            if delta is None:
+                lines.append(f"{guild}: {count}")
+            else:
+                sign = "+" if delta >= 0 else ""
+                lines.append(f"{guild}: {count} ({sign}{delta})")
+        await itx.followup.send("\n".join(lines), ephemeral=True)
+        _log_cmd("wowactive_guilds", t0, rows=len(rows), days=days, limit=limit)
+
     @app_commands.command(name="wowah_hot", description="Most listed items on AH")
     @app_commands.describe(limit="Max rows (default 10)")
     async def wowah_hot(itx: discord.Interaction, limit: int = 10):
@@ -141,6 +166,7 @@ def setup_kpi(tree: app_commands.CommandTree):
     tree.add_command(wowgold_top)
     tree.add_command(wowlevels)
     tree.add_command(wowguilds)
+    tree.add_command(wowactive_guilds)
     tree.add_command(wowah_hot)
     tree.add_command(wowarena)
     tree.add_command(wowprof)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,6 +21,7 @@ Commands
 - /wowgold_top [limit]
 - /wowlevels — level distribution
 - /wowguilds [days=14] [limit=10]
+- /wowactive_guilds [days=14] [limit=10]
 - /wowah_hot [limit=10] — auction hot items (by item_template)
 - /wowarena [top=20] — rating:teams pairs
 - /wowprof [skill_id] [min_value=300] — profession counts


### PR DESCRIPTION
## Summary
- add `active_guilds` query to count guild members active within a window
- add `/wowactive_guilds` slash command showing counts and cached deltas
- document new command in README and metrics docs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bfa00fa910832e9c043905d12aee1a